### PR TITLE
Slider Improvements

### DIFF
--- a/src/widgets/slider.lua
+++ b/src/widgets/slider.lua
@@ -4,10 +4,11 @@ local Runtime = require(script.Parent.Parent.Runtime)
 local Style = require(script.Parent.Parent.Style)
 local create = require(script.Parent.Parent.create)
 
-return Runtime.widget(function(max)
-	local value, setValue = Runtime.useState(0)
+return Runtime.widget(function(options)
+	local max = options.max
+	local value, setValue = Runtime.useState(options.initial or 0)
 
-	Runtime.useInstance(function()
+	local refs = Runtime.useInstance(function(ref)
 		local style = Style.get()
 
 		local frame = create("Frame", {
@@ -25,8 +26,9 @@ return Runtime.widget(function(max)
 			create("TextButton", {
 				Name = "dot",
 				Size = UDim2.new(0, 15, 0, 15),
+				AnchorPoint = Vector2.new(0.5, 0.5),
 				BackgroundColor3 = style.textColor,
-				Position = UDim2.new(0, 0, 0.5, -7),
+				Position = UDim2.new(0, 0, 0.5, 0),
 				Text = "",
 
 				create("UICorner", {
@@ -34,6 +36,8 @@ return Runtime.widget(function(max)
 				}),
 			}),
 		})
+
+		ref.frame = frame
 
 		local inputs = {}
 
@@ -49,12 +53,11 @@ return Runtime.widget(function(max)
 
 				local x = UserInputService:GetMouseLocation().X
 
-				x -= frame.AbsolutePosition.X
-				x = math.clamp(x, 0, frame.AbsoluteSize.X)
+				local maxPos = frame.AbsoluteSize.X - frame.dot.AbsoluteSize.X
+				x -= frame.AbsolutePosition.X + frame.dot.AbsoluteSize.X/2
+				x = math.clamp(x, 0, maxPos)
 
-				local percent = x / frame.AbsoluteSize.X
-
-				frame.dot.Position = UDim2.new(0, x, 0.5, -7)
+				local percent = x / maxPos
 
 				setValue(percent * max)
 			end)
@@ -68,6 +71,10 @@ return Runtime.widget(function(max)
 
 		return frame
 	end)
+
+	local maxPos = refs.frame.AbsoluteSize.X - refs.frame.dot.AbsoluteSize.X
+	local percent = value / max
+	refs.frame.dot.Position = UDim2.new(0, percent * maxPos + refs.frame.dot.AbsoluteSize.X/2, 0.5, 0)
 
 	return value
 end)

--- a/src/widgets/slider.lua
+++ b/src/widgets/slider.lua
@@ -5,18 +5,19 @@ local Style = require(script.Parent.Parent.Style)
 local create = require(script.Parent.Parent.create)
 
 return Runtime.widget(function(options)
-	local max = options.max
+	local min = options.min or 0
+	local max = options.max or 1
 	local value, setValue = Runtime.useState(options.initial or 0)
 
 	local refs = Runtime.useInstance(function(ref)
 		local style = Style.get()
 
 		local frame = create("Frame", {
+			[ref] = "frame",
 			BackgroundTransparency = 1,
 			Size = UDim2.new(0, 200, 0, 30),
 
 			create("Frame", {
-				[ref] = "frame",
 				Name = "line",
 				Size = UDim2.new(1, 0, 0, 2),
 				BackgroundColor3 = style.mutedTextColor,
@@ -58,7 +59,7 @@ return Runtime.widget(function(options)
 
 				local percent = x / maxPos
 
-				setValue(percent * max)
+				setValue(percent * (max - min) + min)
 			end)
 		end)
 
@@ -72,7 +73,7 @@ return Runtime.widget(function(options)
 	end)
 
 	local maxPos = refs.frame.AbsoluteSize.X - refs.frame.dot.AbsoluteSize.X
-	local percent = value / max
+	local percent = (value - min) / (max - min)
 	refs.frame.dot.Position = UDim2.new(0, percent * maxPos + refs.frame.dot.AbsoluteSize.X/2, 0.5, 0)
 
 	return value

--- a/src/widgets/slider.lua
+++ b/src/widgets/slider.lua
@@ -16,6 +16,7 @@ return Runtime.widget(function(options)
 			Size = UDim2.new(0, 200, 0, 30),
 
 			create("Frame", {
+				[ref] = "frame",
 				Name = "line",
 				Size = UDim2.new(1, 0, 0, 2),
 				BackgroundColor3 = style.mutedTextColor,
@@ -36,8 +37,6 @@ return Runtime.widget(function(options)
 				}),
 			}),
 		})
-
-		ref.frame = frame
 
 		local inputs = {}
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9200592/177248066-28f017f7-b3b1-4e41-b8ff-487b854e3463.png)

- Changed slider parameter to be a table of options. Current values are:
  - `min: number`, defaults to `0`
  - `max: number`, defaults to `1`
  - `initial: number`, defaults to `0`
- Clamped dot to end of slider. Previously, it would go just beyond the slider.