### PR TITLE
maxSize considers space between container and parent

### DIFF
--- a/src/automaticSize.lua
+++ b/src/automaticSize.lua
@@ -12,10 +12,11 @@ local function applyLayout(container, layout)
 			maxSize = Vector2.new(0, 0)
 		else
 			local parentSize = container.Parent.AbsoluteSize
+			local parentPosition = container.Parent.AbsolutePosition
 
 			maxSize = Vector2.new(
-				(parentSize.X / maxSize.X.Scale) + maxSize.X.Offset,
-				(parentSize.Y / maxSize.Y.Scale) + maxSize.Y.Offset
+				(parentSize.X / maxSize.X.Scale) + maxSize.X.Offset - (container.AbsolutePosition.X - parentPosition.X),
+				(parentSize.Y / maxSize.Y.Scale) + maxSize.Y.Offset - (container.AbsolutePosition.Y - parentPosition.Y)
 			)
 		end
 	end


### PR DESCRIPTION
Currently, if the container element is offset from its parent, it doesn't consider the offset pixels when determining the maxSize. This makes the size of the container larger than it should be by said offset. This change considers the space between the `AbsolutePosition` of the container and the `AbsolutePosition` of the parent.