### PR TITLE
fix hot reload min/max change breaking slider

### DIFF
--- a/src/widgets/slider.lua
+++ b/src/widgets/slider.lua
@@ -14,7 +14,9 @@ return Runtime.widget(function(options)
 
 	local min = options.min or 0
 	local max = options.max or 1
-	local value, setValue = Runtime.useState(options.initial or 0)
+	local initial = options.initial or 0
+	local initpercent = (initial - min) / (max - min)
+	local precentageValue, setPrecentageValue = Runtime.useState(initpercent)
 
 	local refs = Runtime.useInstance(function(ref)
 		local connect = createConnect()
@@ -70,8 +72,8 @@ return Runtime.widget(function(options)
 						x = math.clamp(x, 0, maxPos)
 
 						local percent = x / maxPos
-
-						setValue(percent * (max - min) + min)
+						
+						setPrecentageValue(percent)
 					end)
 				end,
 
@@ -92,8 +94,8 @@ return Runtime.widget(function(options)
 	end)
 
 	local maxPos = refs.frame.AbsoluteSize.X - refs.frame.dot.AbsoluteSize.X
-	local percent = (value - min) / (max - min)
-	refs.frame.dot.Position = UDim2.new(0, percent * maxPos + refs.frame.dot.AbsoluteSize.X / 2, 0.5, 0)
+	refs.frame.dot.Position = UDim2.new(0, precentageValue * maxPos + refs.frame.dot.AbsoluteSize.X / 2, 0.5, 0)
 
+	local value = precentageValue * (max - min) + min
 	return value
 end)


### PR DESCRIPTION
# fix hot reload min/max change breaking slider
## Problem
if you change the min or max values with a hot reload the slider beaks
The slider will still think the initial min and max variables are the current once even after changing them.
This causes the following problems:
1. Making it smaller makes you not able to use the full slider.
2. Making it bigger makes the dot go off screen.

## My solution 
Change it so that useInstance only sets a percentage with out knowing the min and max value.
This fixes both problems put above.
This means that I changed the value state to a percentage state and calculate the value every frame.

## Changed behaver
This fix changes the behaver of the slider once the values are changed.
Before value stayed the same even if the min and max changed
After now the percentage will stay the same meaning the value changes if min and max are changed