### PR TITLE
Fixed table cell automatic text sizing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ Packages
 roblox.toml
 build
 plasma.rbxm
+sourcemap.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.4.3] - UNRELEASED
+### Fixed
+- Fixed table cell automatic text sizing 
+
 ## [0.4.2] - 2022-07-10
 ### Fixed
 - Fixed Slider not firing event callback for drag connection (Fixes using slider on the server in Matter debugger)

--- a/src/widgets/table.lua
+++ b/src/widgets/table.lua
@@ -8,11 +8,10 @@ local cell = Runtime.widget(function(text, font)
 	local refs = Runtime.useInstance(function(ref)
 		local style = Style.get()
 
-		return create("TextLabel", {
+		local cellLabel = create("TextLabel", {
 			[ref] = "label",
 			BackgroundTransparency = 1,
 			Font = Enum.Font.SourceSans,
-			AutomaticSize = Enum.AutomaticSize.XY,
 			TextColor3 = style.textColor,
 			TextSize = 20,
 			TextXAlignment = Enum.TextXAlignment.Left,
@@ -25,6 +24,10 @@ local cell = Runtime.widget(function(text, font)
 				PaddingTop = UDim.new(0, 8),
 			}),
 		})
+
+		automaticSize(cellLabel, { axis = Enum.AutomaticSize.XY })
+
+		return cellLabel
 	end)
 
 	refs.label.Font = font or Enum.Font.SourceSans


### PR DESCRIPTION
Due to a change on Roblox's side, labels inside of a table cell are incorrectly sized if the AutomaticSize property is set. The solution is to use Plasma's custom AutomaticSize implementation. 