### PR TITLE
Expose context functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## UNRELEASED
+### Added
+- The context functions are now exposed in `init.lua`
+
 ### Fixed
 - automaticSize helper should now set minSize attribute correctly 
 

--- a/src/init.lua
+++ b/src/init.lua
@@ -16,6 +16,9 @@ return {
 	useEffect = Runtime.useEffect,
 	useKey = Runtime.useKey,
 	setEventCallback = Runtime.setEventCallback,
+	createContext = Runtime.createContext,
+	useContext = Runtime.useContext,
+	provideContext = Runtime.provideContext,
 
 	useStyle = Style.get,
 	setStyle = Style.set,


### PR DESCRIPTION
Context is such a useful feature in plasma and I don't think it makes sense that its functions still can't be imported from the main file. Maybe this was an oversight?