### PR TITLE
Fix window position reseting while being dragged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 - The context functions are now exposed in `init.lua`
 
 ### Fixed
-- automaticSize helper should now set minSize attribute correctly 
+- automaticSize helper should now set minSize attribute correctly
+- Fixed the window the window position reseting when another input state update is processed while the window is moving
 
 ## [0.4.2] - 2022-07-10
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 - automaticSize helper should now set minSize attribute correctly
-- Fixed the window the window position reseting when another input state update is processed while the window is moving
+- Fixed the window position reseting when another input state update is processed while the window is being dragged
 
 ## [0.4.2] - 2022-07-10
 ### Fixed

--- a/src/widgets/window.lua
+++ b/src/widgets/window.lua
@@ -101,6 +101,10 @@ return Runtime.widget(function(options, fn)
 					end
 
 					dragConnection = connect(UserInputService, "InputChanged", function(moveInput)
+						if moveInput.UserInputType ~= Enum.UserInputType.MouseMovement then
+							return
+						end
+
 						local delta = lastMousePosition - moveInput.Position
 
 						lastMousePosition = moveInput.Position


### PR DESCRIPTION
If another input is still being processed while dragging a window, Plasma resets the window position until it stops receiving other input state changes. In the example below, I was holding the `F` key while dragging around a window. The issue can be fixed by just filtering `dragConnection` to only accept mouse movement updates.

![plasma_bug](https://github.com/evaera/plasma/assets/46044567/90d1087e-68f7-4885-a1ea-9b6d14a6e529)