### PR TITLE
Detect heading click and provide clicked cell in table widget

### DIFF
--- a/src/widgets/table.lua
+++ b/src/widgets/table.lua
@@ -103,7 +103,8 @@ local row = Runtime.widget(function(columns, darken, selectable, font)
 				setClicked(nil)
 				return clicked
 			end
-			return false
+
+			return nil
 		end,
 		hovered = function()
 			return hovering
@@ -117,8 +118,15 @@ end)
 	@param items {{string}}
 	@param options {marginTop?: number, selectable?: boolean, font?: Font, headings?: boolean}
 	@tag widgets
+	@return TableWidgetHandle
 
-	A table widget. Items is a list of rows, with each row being a list of cells.
+	A table widget. Items is a list of rows, with each row being a list of cells. 
+
+	Returns a widget handle, which has the fields:
+
+	- `selected`, a function you can call to check what row and cell were selected this frame, if any
+	- `selectedHeading`, a function you can call to check which heading was selected this frame, if any
+	- `hovered`, a function you can call to check what row is being hovered over
 
 	```lua
 	local items = {
@@ -192,7 +200,7 @@ return Runtime.widget(function(items, options)
 		local clickedCell = currentRow:clicked()
 		if clickedCell then
 			if isHeading then
-				setSelectedHeading({ row = columns, cell = clickedCell })
+				setSelectedHeading(clickedCell)
 			else
 				setSelected({ row = columns, cell = clickedCell })
 			end
@@ -207,7 +215,7 @@ return Runtime.widget(function(items, options)
 		selectedHeading = function()
 			if selectedHeading then
 				setSelectedHeading(nil)
-				return selectedHeading.row, selectedHeading.cell
+				return selectedHeading
 			end
 
 			return nil

--- a/src/widgets/table.lua
+++ b/src/widgets/table.lua
@@ -204,7 +204,6 @@ return Runtime.widget(function(items, options)
 	end
 
 	return {
-		--selectedHeading = function() end,
 		selectedHeading = function()
 			if selectedHeading then
 				setSelectedHeading(nil)

--- a/src/widgets/table.lua
+++ b/src/widgets/table.lua
@@ -87,12 +87,12 @@ local row = Runtime.widget(function(columns, darken, selectable, font)
 	refs.row.BackgroundTransparency = transparency
 	refs.row.BackgroundColor3 = selected and Color3.fromHex("bd515c") or Color3.fromRGB(0, 0, 0)
 
-	for _, column in ipairs(columns) do
+	for index, column in ipairs(columns) do
 		if type(column) == "function" then
 			Runtime.scope(column)
 		else
 			if cell(column, font):clicked() then
-				setClicked(column)
+				setClicked(index)
 			end
 		end
 	end
@@ -202,7 +202,7 @@ return Runtime.widget(function(items, options)
 			if isHeading then
 				setSelectedHeading(clickedCell)
 			else
-				setSelected({ row = columns, cell = clickedCell })
+				setSelected({ row = columns, cellIndex = clickedCell })
 			end
 		end
 
@@ -223,7 +223,7 @@ return Runtime.widget(function(items, options)
 		selected = function()
 			if selected then
 				setSelected(nil)
-				return selected.row, selected.cell
+				return selected.row, selected.cellIndex
 			end
 
 			return nil

--- a/src/widgets/table.lua
+++ b/src/widgets/table.lua
@@ -176,7 +176,7 @@ return Runtime.widget(function(items, options)
 	end)
 
 	local selected, setSelected = Runtime.useState()
-	--local selectedHeading, setSelectedHeading = Runtime.useState()
+	local selectedHeading, setSelectedHeading = Runtime.useState()
 	local hovered
 
 	for i, columns in items do
@@ -192,7 +192,7 @@ return Runtime.widget(function(items, options)
 		local clickedCell = currentRow:clicked()
 		if clickedCell then
 			if isHeading then
-				--setSelectedHeading()
+				setSelectedHeading({ row = columns, cell = clickedCell })
 			else
 				setSelected({ row = columns, cell = clickedCell })
 			end
@@ -205,11 +205,21 @@ return Runtime.widget(function(items, options)
 
 	return {
 		--selectedHeading = function() end,
+		selectedHeading = function()
+			if selectedHeading then
+				setSelectedHeading(nil)
+				return selectedHeading.row, selectedHeading.cell
+			end
+
+			return nil
+		end,
 		selected = function()
 			if selected then
 				setSelected(nil)
 				return selected.row, selected.cell
 			end
+
+			return nil
 		end,
 		hovered = function()
 			return hovered

--- a/src/widgets/table.lua
+++ b/src/widgets/table.lua
@@ -10,7 +10,7 @@ local cell = Runtime.widget(function(text, font)
 		local style = Style.get()
 
 		return create("TextButton", {
-			[ref] = "label",
+			[ref] = "button",
 			BackgroundTransparency = 1,
 			Font = Enum.Font.SourceSans,
 			AutomaticSize = Enum.AutomaticSize.XY,
@@ -18,6 +18,7 @@ local cell = Runtime.widget(function(text, font)
 			TextSize = 20,
 			TextXAlignment = Enum.TextXAlignment.Left,
 			RichText = true,
+			AutoButtonColor = false,
 			Active = true,
 
 			Activated = function()
@@ -33,8 +34,8 @@ local cell = Runtime.widget(function(text, font)
 		})
 	end)
 
-	refs.label.Font = font or Enum.Font.SourceSans
-	refs.label.Text = text
+	refs.button.Font = font or Enum.Font.SourceSans
+	refs.button.Text = text
 
 	return {
 		clicked = function()
@@ -58,7 +59,6 @@ local row = Runtime.widget(function(columns, darken, selectable, font)
 			[ref] = "row",
 			BackgroundTransparency = if darken then 0.7 else 1,
 			BackgroundColor3 = Color3.fromRGB(0, 0, 0),
-			--AutoButtonColor = false,
 			Text = "",
 			Active = false,
 

--- a/stories/table.story.lua
+++ b/stories/table.story.lua
@@ -27,20 +27,18 @@ return function(target)
 
 					local selectedHeading = tbl:selectedHeading()
 					if headings[selectedHeading] == headings[1] then
+						-- Sort alphabetically
 						table.sort(items, function(a, b)
 							return a[1] < b[1]
 						end)
 					elseif headings[selectedHeading] == headings[2] then
+						-- Sort by count
 						table.sort(items, function(a, b)
 							return a[2] < b[2]
 						end)
 					end
 
 					local selectedRow, cellIndex = tbl:selected()
-					if selectedRow then
-						print(selectedRow, cellIndex)
-					end
-
 					if cellIndex == 1 then
 						-- Remove row if click name
 						table.remove(items, table.find(items, selectedRow))

--- a/stories/table.story.lua
+++ b/stories/table.story.lua
@@ -1,0 +1,33 @@
+local RunService = game:GetService("RunService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Plasma = require(ReplicatedStorage.Plasma)
+
+return function(target)
+	local root = Plasma.new(target)
+
+	local connection = RunService.Heartbeat:Connect(function()
+		Plasma.start(root, function()
+			Plasma.window("Spinner", function()
+				Plasma.row({
+					alignment = Enum.HorizontalAlignment.Center,
+				}, function()
+					local tbl = Plasma.table({
+						{ "Name", "Count" },
+						{ "Test", "3" },
+						{ " More Test", "4" },
+					}, {
+						headings = true,
+						selectable = true,
+					})
+
+					--print(tbl:selected())
+				end)
+			end)
+		end)
+	end)
+
+	return function()
+		connection:Disconnect()
+		Plasma.start(root, function() end)
+	end
+end

--- a/stories/table.story.lua
+++ b/stories/table.story.lua
@@ -4,6 +4,11 @@ local Plasma = require(ReplicatedStorage.Plasma)
 
 return function(target)
 	local root = Plasma.new(target)
+	local heading = { "Name", "Count" }
+	local items = {
+		{ "Test", 3 },
+		{ "More Test", 4 },
+	}
 
 	local connection = RunService.Heartbeat:Connect(function()
 		Plasma.start(root, function()
@@ -11,15 +16,26 @@ return function(target)
 				Plasma.row({
 					alignment = Enum.HorizontalAlignment.Center,
 				}, function()
-					local tbl = Plasma.table({
-						{ "Name", "Count" },
-						{ "Test", "3" },
-						{ " More Test", "4" },
-					}, {
+					local selectedHeading
+
+					local entry = table.clone(items)
+					table.insert(entry, 1, heading)
+
+					local tbl = Plasma.table(entry, {
 						headings = true,
 						selectable = true,
 					})
 
+					_, selectedHeading = tbl:selectedHeading()
+					if selectedHeading == "Name" then
+						table.sort(items, function(a, b)
+							return a[1] < b[1]
+						end)
+					elseif selectedHeading == "Count" then
+						table.sort(items, function(a, b)
+							return a[2] < b[2]
+						end)
+					end
 					--print(tbl:selected())
 				end)
 			end)

--- a/stories/table.story.lua
+++ b/stories/table.story.lua
@@ -25,7 +25,7 @@ return function(target)
 						selectable = true,
 					})
 
-					local _, selectedHeading = tbl:selectedHeading()
+					local selectedHeading = tbl:selectedHeading()
 					if selectedHeading == "Name" then
 						table.sort(items, function(a, b)
 							return a[1] < b[1]

--- a/stories/table.story.lua
+++ b/stories/table.story.lua
@@ -5,7 +5,7 @@ local Plasma = require(ReplicatedStorage.Plasma)
 return function(target)
 	local root = Plasma.new(target)
 
-	local heading = { "Name", "Count" }
+	local headings = { "Name", "Count" }
 	local items = {}
 	for index, letter in { "A", "B", "C", "D", "E" } do
 		table.insert(items, { letter, 100 - index })
@@ -17,31 +17,36 @@ return function(target)
 				Plasma.row({
 					alignment = Enum.HorizontalAlignment.Center,
 				}, function()
-					local entry = table.clone(items)
-					table.insert(entry, 1, heading)
+					local entries = table.clone(items)
+					table.insert(entries, 1, headings)
 
-					local tbl = Plasma.table(entry, {
+					local tbl = Plasma.table(entries, {
 						headings = true,
 						selectable = true,
 					})
 
 					local selectedHeading = tbl:selectedHeading()
-					if selectedHeading == "Name" then
+					if headings[selectedHeading] == headings[1] then
 						table.sort(items, function(a, b)
 							return a[1] < b[1]
 						end)
-					elseif selectedHeading == "Count" then
+					elseif headings[selectedHeading] == headings[2] then
 						table.sort(items, function(a, b)
 							return a[2] < b[2]
 						end)
 					end
 
-					local selectedRow, selectedCell = tbl:selected()
-					if selectedCell then
-						local index = table.find(selectedRow, selectedCell)
-						if index == 2 then
-							selectedRow[index] = Random.new():NextInteger(1, 100)
-						end
+					local selectedRow, cellIndex = tbl:selected()
+					if selectedRow then
+						print(selectedRow, cellIndex)
+					end
+
+					if cellIndex == 1 then
+						-- Remove row if click name
+						table.remove(items, table.find(items, selectedRow))
+					elseif cellIndex == 2 then
+						-- Shuffle number if click count
+						selectedRow[cellIndex] = Random.new():NextInteger(1, 100)
 					end
 				end)
 			end)

--- a/stories/table.story.lua
+++ b/stories/table.story.lua
@@ -4,20 +4,19 @@ local Plasma = require(ReplicatedStorage.Plasma)
 
 return function(target)
 	local root = Plasma.new(target)
+
 	local heading = { "Name", "Count" }
-	local items = {
-		{ "Test", 3 },
-		{ "More Test", 4 },
-	}
+	local items = {}
+	for index, letter in { "A", "B", "C", "D", "E" } do
+		table.insert(items, { letter, 100 - index })
+	end
 
 	local connection = RunService.Heartbeat:Connect(function()
 		Plasma.start(root, function()
-			Plasma.window("Spinner", function()
+			Plasma.window("Table", function()
 				Plasma.row({
 					alignment = Enum.HorizontalAlignment.Center,
 				}, function()
-					local selectedHeading
-
 					local entry = table.clone(items)
 					table.insert(entry, 1, heading)
 
@@ -26,7 +25,7 @@ return function(target)
 						selectable = true,
 					})
 
-					_, selectedHeading = tbl:selectedHeading()
+					local _, selectedHeading = tbl:selectedHeading()
 					if selectedHeading == "Name" then
 						table.sort(items, function(a, b)
 							return a[1] < b[1]
@@ -36,7 +35,14 @@ return function(target)
 							return a[2] < b[2]
 						end)
 					end
-					--print(tbl:selected())
+
+					local selectedRow, selectedCell = tbl:selected()
+					if selectedCell then
+						local index = table.find(selectedRow, selectedCell)
+						if index == 2 then
+							selectedRow[index] = Random.new():NextInteger(1, 100)
+						end
+					end
 				end)
 			end)
 		end)


### PR DESCRIPTION
Adds `:selectedHeading()`, which returns the table heading that was clicked this frame. It also changes `:selected()` to return the index of the cell that was clicked, instead of just the row, as a second return value. 

IMO these methods are both misnomers because they don't do any selection on their own, but renaming `:selected()` would be a breaking change (and this PR aims to avoid that.)

A new table story has been added to show how these might now be used.